### PR TITLE
writeOrFlush on Serial2 data handling in loop

### DIFF
--- a/konekt_user_module_serial_gateway/konekt_user_module_serial_gateway.ino
+++ b/konekt_user_module_serial_gateway/konekt_user_module_serial_gateway.ino
@@ -83,7 +83,7 @@ void loop() {
   isHandlingData = false;
 
   while(Serial2.available()) {
-    writeOrFlush(Serial2.available());
+    writeOrFlush(Serial2.read());
   }
 
   while(SerialUSB.available()) {


### PR DESCRIPTION
Not sure why GitHub is showing 117 additions... 
Line 86 was the only change

writeOrFlush(Serial2.available()); 
should be 
writeOrFlush(Serial2.read());